### PR TITLE
Changed to comply with provider in version 0.12

### DIFF
--- a/3-string-interpolation/README.md
+++ b/3-string-interpolation/README.md
@@ -39,7 +39,10 @@ resource "azurerm_container_group" "vote-app" {
     image  = "microsoft/aci-helloworld"
     cpu    = "0.5"
     memory = "1.5"
-    port   = "80"
+    ports {
+      port   = 80
+      protocol ="TCP"
+    }
   }
 }
 ```


### PR DESCRIPTION
changed the port definition in Section 3 to fix deprecated port definition.

from:
port   = "80"

to:
    ports {
      port   = 80
      protocol ="TCP"
    }
